### PR TITLE
If player have 0 balance, don't save to database there

### DIFF
--- a/src/main/java/me/playernguyen/opteco/account/OptEcoCacheAccount.java
+++ b/src/main/java/me/playernguyen/opteco/account/OptEcoCacheAccount.java
@@ -32,6 +32,7 @@ public class OptEcoCacheAccount {
     }
 
     public static OptEcoCacheAccount loadFromAccount(Account account) {
-        return new OptEcoCacheAccount(account.getBalance(), System.currentTimeMillis());
+        if (account != null) return new OptEcoCacheAccount(account.getBalance(), System.currentTimeMillis());
+    	else return new OptEcoCacheAccount(0, System.currentTimeMillis());
     }
 }

--- a/src/main/java/me/playernguyen/opteco/account/OptEcoCacheAccountManager.java
+++ b/src/main/java/me/playernguyen/opteco/account/OptEcoCacheAccountManager.java
@@ -43,8 +43,10 @@ public class OptEcoCacheAccountManager {
             throw new NullPointerException("UUID not found to refresh");
         }
         // Account replace
-        Account account = getOptEco().getAccountDatabase().requestAccountInformation(uuid);
-        this.getMap().replace(uuid, new OptEcoCacheAccount(account.getBalance(), System.currentTimeMillis()));
+        Account account = getOptEco().getAccountDatabase().getAccountIdentify(uuid);
+        double accountmoney = 0;
+        if(account != null) accountmoney = account.getBalance();
+        this.getMap().replace(uuid, new OptEcoCacheAccount(accountmoney, System.currentTimeMillis()));
     }
 
     public OptEcoCacheAccount get(UUID uuid) {
@@ -71,11 +73,14 @@ public class OptEcoCacheAccountManager {
         // If not found account, create one and put to manager
         //   Check account on database,
         //     If exist -> get current,
-        //     Not exist -> create new with start balance
-        Account account = (this.getOptEco().getAccountDatabase().hasAccount(uuid)) ?
-                this.getOptEco().getAccountDatabase().requestAccountInformation(uuid) :
-                new Account(uuid, getOptEco().getConfigurationLoader().getDouble(OptEcoConfiguration
-                        .START_BALANCE));
+        //     Not exist -> create new with start balance (if start_balance != 0)
+        Account account = null;
+        if (this.getOptEco().getAccountDatabase().hasAccount(uuid)) {
+        	account = this.getOptEco().getAccountDatabase().requestAccountInformation(uuid);
+        } else if(this.getOptEco().getConfigurationLoader().getDouble(OptEcoConfiguration.START_BALANCE) != 0) {
+        	account = new Account(uuid, getOptEco().getConfigurationLoader().getDouble(OptEcoConfiguration
+                    .START_BALANCE));
+        }
 
         // Then return account
         this.map.put(uuid, OptEcoCacheAccount.loadFromAccount(account));

--- a/src/main/java/me/playernguyen/opteco/account/SQLAccountDatabase.java
+++ b/src/main/java/me/playernguyen/opteco/account/SQLAccountDatabase.java
@@ -132,7 +132,7 @@ public abstract class SQLAccountDatabase extends OptEcoImplementation
 
     @Override
     public boolean hasAccount(UUID uuid) {
-        return requestAccountInformation(uuid) != null;
+        return getAccountIdentify(uuid) != null;
     }
 
     @Override


### PR DESCRIPTION
This should reduce the size of the databases.
Often players just go in and out of the server, and their zero balance remains, I decided to fix this without saving his balance if 0 points (if the player was once with the money, and then zero again, I do not delete it). I checked that the commands work, /points me, check, set and PlaceloderAPI are working.
If you have any comments on my changes, tell me where I went wrong.